### PR TITLE
fix: styled text with ⏎ in a <li> fails

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -137,6 +137,30 @@ function code(section) {
   return section;
 }
 
+function fragmentLi($) {
+  const list = $('li');
+  if (list.length === 0) return;
+  list.each((i, el) => {
+    el = $(el);
+    let text = el.text();
+    if (text.includes('⏎')) {
+      el.addClass('fragment');
+      const children = el.children();
+      if (children.length === 0) {
+        text = text.replace('⏎', '');
+        el.text(text);
+        return;
+      }
+      children.each((i, child) => {
+        if (child.next && child.next.data && child.next.data.includes('⏎')) {
+          const text = child.next.data.replace('⏎', '');
+          child.next.data = text;
+        }
+      });
+    }
+  });
+}
+
 function fragmentTags($, tagName) {
   const list = $(tagName);
   if (list.length === 0) return;
@@ -164,7 +188,7 @@ function fragmentTags($, tagName) {
 
 function fragment(section) {
   const $ = cheerio.load(section);
-  fragmentTags($, 'li');
+  fragmentLi($);
   fragmentTags($, 'p');
   return $.html();
 }

--- a/lib/spec/index.spec.js
+++ b/lib/spec/index.spec.js
@@ -3,6 +3,10 @@ const cheerio = require('cheerio');
 const { convertImageSrcSet, sanitizeImageSrc, setHost, splitPinnedPages, parseParams } = require('../util');
 const { fragment } = require('../plugin');
 
+function html(inner) {
+  return '<html><head></head><body>' + inner + '</body></html>';
+}
+
 describe('miniseminar', () => {
   setHost('https://confluency.atlassian.net');
 
@@ -33,24 +37,40 @@ describe('miniseminar', () => {
         theme: 'Confluence'
       });
   });
-  it('should convert ⏎ in the <li>', () => {
-    const a = '<ul><li>first⏎</li><li>second⏎</li><li>third⏎</li></ul>';
-    expect(fragment(a))
-      .toEqual(
-        '<ul><li class="fragment">first</li><li class="fragment">second</li><li class="fragment">third</li></ul>'
-      );
-  });
-  it('should convert ⏎ in the <p>', () => {
-    const a = '<p>first⏎</p><p>second⏎</p><p>third⏎</p>';
-    expect(fragment(a))
-      .toEqual(
-        '<p class="fragment">first</p><p class="fragment">second</p><p class="fragment">third</p>'
-      );
-  });
-  it('should convert ⏎ with around an image', () => {
-    expect(fragment(
-        `<p><span class="confluence-embedded-file-wrapper confluence-embedded-manual-size"><img class="confluence-embedded-image confluence-external-resource" height="250" src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82" data-image-src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82"></span>&#x23CE;</p>`))
-      .toEqual(
-        `<p><span class="confluence-embedded-file-wrapper confluence-embedded-manual-size fragment"><img class="confluence-embedded-image confluence-external-resource" height="250" src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82" data-image-src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82"></span></p>`);
-  });
+  describe('fragements', () => {
+    it('should convert ⏎ in the <li>', () => {
+      const a = '<ul><li>first⏎</li><li>second⏎</li><li>third⏎</li></ul>';
+      expect(fragment(a))
+        .toEqual(html(
+          '<ul><li class="fragment">first</li><li class="fragment">second</li><li class="fragment">third</li></ul>'
+        ));
+    });
+    it('should convert ⏎ in the <p>', () => {
+      const a = '<p>first⏎</p><p>second⏎</p><p>third⏎</p>';
+      expect(fragment(a))
+        .toEqual(html(
+          '<p class="fragment">first</p><p class="fragment">second</p><p class="fragment">third</p>'
+        ));
+    });
+    it('should convert ⏎ with around an image', () => {
+      expect(fragment(
+          `<p><span class="confluence-embedded-file-wrapper confluence-embedded-manual-size"><img class="confluence-embedded-image confluence-external-resource" height="250" src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82" data-image-src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82"></span>&#x23CE;</p>`))
+        .toEqual(html(
+          `<p><span class="confluence-embedded-file-wrapper confluence-embedded-manual-size fragment"><img class="confluence-embedded-image confluence-external-resource" height="250" src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82" data-image-src="http://cfile25.uf.tistory.com/image/23028948558D5D6844CB82"></span></p>`));
+    });
+    it('should split by <li>s', () => {
+      const a = '<ul><li>A⏎</li><li>B⏎</li><li><strong>C with style</strong>, C as plain⏎</li></ul>';
+      expect(fragment(a))
+        .toEqual(html(
+          '<ul><li class="fragment">A</li><li class="fragment">B</li><li class="fragment"><strong>C with style</strong>, C as plain</li></ul>'
+        ));
+    });
+    it('should convert nested <li>s', () => {
+      const a = '<ul><li><strong>ha</strong>ha⏎<ul><li>he<strong>he</strong>⏎</li></ul></li></ul>';
+      expect(fragment(a))
+        .toEqual(html(
+          '<ul><li class="fragment"><strong>ha</strong>ha<ul><li class="fragment">he<strong>he</strong></li></ul></li></ul>'
+        ));
+    });
+  })
 });


### PR DESCRIPTION
close #31