### PR TITLE
fix: no display URI encoded background

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -52,7 +52,10 @@ export function backgroundImage(req) {
       const originalSize = !img.attr('height') && !img.attr('width');
       const isEmoticon = img.hasClass('emoticon');
       if (!originalSize || isEmoticon) return;
-      section.background = hostToAbsolute(req) + '/image' + sanitizeImageSrc(img.data('image-src'));
+
+      // backgroundImage should be URI decoded
+      const backgroundImage = decodeURI(sanitizeImageSrc(img.data('image-src')));
+      section.background = hostToAbsolute(req) + '/image' + backgroundImage;
       //section['background-image'] = req.baseUrl + '/image' + sanitizeImageSrc(img.data('image-src'));
       img.remove();
     });


### PR DESCRIPTION
`backgroundImage` will be encoding at [here](https://github.com/hakimel/reveal.js/blob/33bed47daca3f08c396215415e6ece005970734a/js/reveal.js#L3794), the filename encoded twice.